### PR TITLE
fix: Changement CTA à propos (#3)

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -43,16 +43,14 @@ const AboutSection = () => {
                                 }}
                             >
 
-                                <p>Menuisier depuis 2000 et après avoir travaillé dans diverses menuiserie je me suis mis à mon compte en 2022 dans le perche,afin de proposer mes  propres réalisations aux clients.</p>
+                                <p>Menuisier depuis 2000 et après avoir travaillé dans diverses menuiseries, je me suis mis à mon compte en 2022 dans le perche afin de proposer mes propres réalisations aux clients.</p>
 
 
                                 <p>Je réalise  vos ouvrages en bois que ce soit pour l'intérieur de votre habitation ou à l'extérieur de celle-ci.
                                     Je m'entretiens personnellement avec chacun de mes clients afin de voir leurs besoins, leurs idées et d'étudier leurs demandes.</p>
 
 
-                                <p>Je vous propose de découvrir sur ce site les différentes ouvrage en bois que ce soit pour l'intérieur de votre habitation ou à l'extérieur de celle-ci
-                                    N'y voyez pas là un catalogue mais plutôt une source d'inspiration.
-                                    Cela vous donnera peut-être des idées des envies de projet et si vous avez besoin de concrétiser vos souhaits n'hésitez pas à me contacter.</p>                          </Typography>
+                                <p>De découvrir sur ce site quelques-unes de mes différents ouvrages et réalisation en bois et matériaux associés.</p>                          </Typography>
                         </Box>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
## Résolution de l'issue #3

**Issue :** Changement CTA à propos

## Cause du bug

Dans [src/components/AboutSection.tsx](src/components/AboutSection.tsx), deux problèmes dans les paragraphes de la section À propos :
- Faute de frappe ("menuiserie" sans 's') et virgule mal placée dans le premier paragraphe
- Troisième paragraphe à remplacer par le nouveau texte fourni

## Changements effectués

- [src/components/AboutSection.tsx](src/components/AboutSection.tsx) ligne 46 : "menuiserie" → "menuiseries,", déplacement de la virgule de "perche,afin" → "perche afin"
- [src/components/AboutSection.tsx](src/components/AboutSection.tsx) lignes 53-55 : remplacement du paragraphe "Je vous propose de découvrir..." par "De découvrir sur ce site quelques-unes de mes différents ouvrages et réalisation en bois et matériaux associés."

## Test

- [ ] Vérifier que les corrections de virgules sont visibles dans la section À propos
- [ ] Vérifier que le nouveau texte de découverte s'affiche correctement
- [ ] Vérifier l'absence de régression sur les autres sections

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)