### PR TITLE
fix: Changement CTA catalogue (#4)

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -50,9 +50,7 @@ const AboutSection = () => {
                                     Je m'entretiens personnellement avec chacun de mes clients afin de voir leurs besoins, leurs idées et d'étudier leurs demandes.</p>
 
 
-                                <p>Je vous propose de découvrir sur ce site les différentes ouvrage en bois que ce soit pour l'intérieur de votre habitation ou à l'extérieur de celle-ci
-                                    N'y voyez pas là un catalogue mais plutôt une source d'inspiration.
-                                    Cela vous donnera peut-être des idées des envies de projet et si vous avez besoin de concrétiser vos souhaits n'hésitez pas à me contacter.</p>                          </Typography>
+                                <p>Je vous propose de découvrir sur ce site quelques différents ouvrages et réalisations en bois et matériaux associés de ma conception. N'y voyez pas là un catalogue mais plutôt une source d'inspiration. Cela vous donnera peut-être des idées des envies de projet. Si vous désirez les concrétiser contactez-moi.</p>                          </Typography>
                         </Box>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
## Résolution de l'issue #4

**Issue :** Changement CTA catalogue

## Cause du bug

Dans [src/components/AboutSection.tsx](src/components/AboutSection.tsx), le troisième paragraphe de la section À propos contenait un texte obsolète et mal formulé pour le CTA catalogue.

## Changements effectués

- [src/components/AboutSection.tsx](src/components/AboutSection.tsx) lignes 53-55 : remplacement du paragraphe par le nouveau texte :
  > "Je vous propose de découvrir sur ce site quelques différents ouvrages et réalisations en bois et matériaux associés de ma conception. N'y voyez pas là un catalogue mais plutôt une source d'inspiration. Cela vous donnera peut-être des idées des envies de projet. Si vous désirez les concrétiser contactez-moi."

## Test

- [ ] Vérifier que le nouveau texte CTA catalogue s'affiche correctement dans la section À propos
- [ ] Vérifier l'absence de régression sur les autres sections de la page

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)