### PR TITLE
fix: Changement CTA naruto et projets (#6)

### DIFF
--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -19,7 +19,7 @@ const ProjectsSection = () => {
                         letterSpacing: '-0.015em',
                     }}
                 >
-                    Nos Projets Récents
+                    Les projets récents
                 </Typography>
 
                 <Grid container spacing={3}>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -10,7 +10,7 @@ export interface Project {
 export const projectsData: Project[] = [
     {
         id: 1,
-        title: 'Étagère Naruto',
+        title: 'Étagère à thème Fanart Naruto',
         description: "Étagère sur mesure inspirée de l'univers Naruto. Un meuble unique alliant passion et savoir-faire artisanal.",
         category: 'Meubles sur mesure',
         coverImage: new URL('../assets/naruto/naruto-detail4.jpeg', import.meta.url).href,


### PR DESCRIPTION
## Résolution de l'issue #6

**Issue :** Changement CTA naruto et projets

## Cause du bug

Deux intitulés à corriger dans le site :
- Le titre de section utilisait "Nos" au lieu de "Les" (ton possessif à éviter)
- Le projet Naruto était nommé trop génériquement

## Changements effectués

- [src/components/ProjectsSection.tsx](src/components/ProjectsSection.tsx) ligne 22 : `Nos Projets Récents` → `Les projets récents`
- [src/data/projects.ts](src/data/projects.ts) ligne 13 : `'Étagère Naruto'` → `'Étagère à thème Fanart Naruto'`

## Test

- [ ] Vérifier que le titre de la section projets affiche bien "Les projets récents"
- [ ] Vérifier que la carte du projet Naruto affiche bien "Étagère à thème Fanart Naruto"
- [ ] Vérifier l'absence de régression sur les autres projets et sections

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)