### PR TITLE
fix: Changement CTA réalisations (#7)

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,7 +3,7 @@ import { Box, Container, Grid, Typography, Pagination, Chip } from '@mui/materia
 import { Link } from 'react-router-dom'
 import { projectsData } from '../data/projects'
 
-const categories = ['Tous', 'Cuisines', 'Meubles sur mesure', 'Dressing', 'Aménagements extérieurs', 'Rénovation']
+const categories = ['Tous', 'Cuisines', 'Meubles sur mesure', 'Aménagements intérieur', 'Aménagements extérieurs', 'Rénovation']
 const PROJECTS_PER_PAGE = 9
 
 const Projects = () => {
@@ -46,7 +46,7 @@ const Projects = () => {
               mb: 2,
             }}
           >
-            Nos Réalisations
+            Les réalisations
           </Typography>
           <Typography
             variant="body1"

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -78,7 +78,7 @@ const ProjectsSection = () => {
                         size="large"
                         href="/projects"
                     >
-                        Voir toutes nos réalisations
+                        Voir toutes les réalisations
                     </Button>
                 </Box>
             </Container>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -67,7 +67,7 @@ export const projectsData: Project[] = [
         id: 5,
         title: 'Dressing sur Mesure',
         description: "Aménagement d'un dressing complet avec rangements optimisés. Solution sur mesure pour maximiser l'espace disponible.",
-        category: 'Dressing',
+        category: 'Aménagements intérieur',
         coverImage: new URL('../assets/dressing/WhatsApp Image 2025-07-14 at 10.25.21 (1).jpeg', import.meta.url).href,
         images: [
             new URL('../assets/dressing/WhatsApp Image 2025-07-14 at 10.25.21 (1).jpeg', import.meta.url).href,


### PR DESCRIPTION
## Résolution de l'issue #7

**Issue :** Changement CTA réalisations

## Cause du bug

Trois intitulés utilisaient le possessif "nos" au lieu de "les", et l'onglet de filtre "Dressing" devait être renommé en "Aménagements intérieur".

## Changements effectués

- [src/components/ProjectsSection.tsx](src/components/ProjectsSection.tsx) ligne 81 : `Voir toutes nos réalisations` → `Voir toutes les réalisations` (bouton page d'accueil)
- [src/components/Projects.tsx](src/components/Projects.tsx) ligne 49 : `Nos Réalisations` → `Les réalisations` (titre de la page projets)
- [src/components/Projects.tsx](src/components/Projects.tsx) ligne 6 : onglet `'Dressing'` → `'Aménagements intérieur'` dans le tableau des catégories
- [src/data/projects.ts](src/data/projects.ts) ligne 70 : `category: 'Dressing'` → `category: 'Aménagements intérieur'` pour maintenir la cohérence du filtre

## Test

- [ ] Vérifier que le bouton de la page d'accueil affiche "Voir toutes les réalisations"
- [ ] Vérifier que le titre de la page projets affiche "Les réalisations"
- [ ] Vérifier que l'onglet "Aménagements intérieur" apparaît et filtre correctement le projet dressing
- [ ] Vérifier l'absence de régression sur les autres filtres

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)