### PR TITLE
fix: Changement CTA placard (#9)

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,7 +3,7 @@ import { Box, Container, Grid, Typography, Pagination, Chip } from '@mui/materia
 import { Link } from 'react-router-dom'
 import { projectsData } from '../data/projects'
 
-const categories = ['Tous', 'Cuisines', 'Meubles sur mesure', 'Dressing', 'Aménagements extérieurs', 'Rénovation']
+const categories = ['Tous', 'Cuisines', 'Meubles sur mesure', 'Aménagement intérieur', 'Aménagements extérieurs', 'Rénovation']
 const PROJECTS_PER_PAGE = 9
 
 const Projects = () => {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -65,9 +65,9 @@ export const projectsData: Project[] = [
     },
     {
         id: 5,
-        title: 'Dressing sur Mesure',
+        title: 'Placard encastré',
         description: "Aménagement d'un dressing complet avec rangements optimisés. Solution sur mesure pour maximiser l'espace disponible.",
-        category: 'Dressing',
+        category: 'Aménagement intérieur',
         coverImage: new URL('../assets/dressing/WhatsApp Image 2025-07-14 at 10.25.21 (1).jpeg', import.meta.url).href,
         images: [
             new URL('../assets/dressing/WhatsApp Image 2025-07-14 at 10.25.21 (1).jpeg', import.meta.url).href,


### PR DESCRIPTION
## Résolution de l'issue #9

**Issue :** Changement CTA placard

## Cause du bug

Le projet "Dressing sur Mesure" portait un intitulé générique qui ne correspondait pas au contenu réel (un placard encastré), et sa catégorie "Dressing" (affichée comme "pansement" par autocorrect dans l'issue) devait être renommée.

## Changements effectués

- [src/data/projects.ts](src/data/projects.ts) ligne 68 : `'Dressing sur Mesure'` → `'Placard encastré'`
- [src/data/projects.ts](src/data/projects.ts) ligne 70 : `category: 'Dressing'` → `category: 'Aménagement intérieur'`
- [src/components/Projects.tsx](src/components/Projects.tsx) ligne 6 : onglet `'Dressing'` → `'Aménagement intérieur'` pour rester cohérent avec la catégorie du projet

## Test

- [ ] Vérifier que la carte du projet affiche bien "Placard encastré"
- [ ] Vérifier que la catégorie affichée sous le titre est "Aménagement intérieur"
- [ ] Vérifier que l'onglet "Aménagement intérieur" filtre correctement ce projet
- [ ] Vérifier l'absence de régression sur les autres projets et filtres

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)