### PR TITLE
fix: Page rénovation buggé (#10)

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,7 +3,7 @@ import { Box, Container, Grid, Typography, Pagination, Chip } from '@mui/materia
 import { Link } from 'react-router-dom'
 import { projectsData } from '../data/projects'
 
-const categories = ['Tous', 'Cuisines', 'Meubles sur mesure', 'Dressing', 'Aménagements extérieurs', 'Rénovation']
+const categories = ['Tous', 'Cuisines', 'Meubles sur mesure', 'Dressing', 'Aménagements extérieurs']
 const PROJECTS_PER_PAGE = 9
 
 const Projects = () => {
@@ -146,25 +146,27 @@ const Projects = () => {
         </Grid>
 
         {/* Pagination */}
-        <Box sx={{ mt: 10, display: 'flex', justifyContent: 'center' }}>
-          <Pagination
-            count={totalPages}
-            page={page}
-            onChange={handlePageChange}
-            shape="rounded"
-            color="primary"
-            sx={{
-              '& .MuiPaginationItem-root': {
-                fontWeight: 600,
-                fontSize: '1rem',
-              },
-              '& .Mui-selected': {
-                backgroundColor: 'primary.main',
-                color: 'white',
-              },
-            }}
-          />
-        </Box>
+        {totalPages > 1 && (
+          <Box sx={{ mt: 10, display: 'flex', justifyContent: 'center' }}>
+            <Pagination
+              count={totalPages}
+              page={page}
+              onChange={handlePageChange}
+              shape="rounded"
+              color="primary"
+              sx={{
+                '& .MuiPaginationItem-root': {
+                  fontWeight: 600,
+                  fontSize: '1rem',
+                },
+                '& .Mui-selected': {
+                  backgroundColor: 'primary.main',
+                  color: 'white',
+                },
+              }}
+            />
+          </Box>
+        )}
       </Container>
     </Box>
   )


### PR DESCRIPTION
## Résolution de l'issue #10

**Issue :** Page rénovation buggé

## Cause du bug

L'onglet "Rénovation" dans la page projets était listé comme catégorie de filtre, mais **aucun projet dans `projects.ts` n'a cette catégorie**. Quand l'utilisateur cliquait dessus :
1. `filteredProjects` retournait un tableau vide → la grille ne rendait rien → fond noir visible
2. `<Pagination count={0} page={1}>` entrait dans un état invalide (page > count), pouvant geler la navigation

## Changements effectués

- [src/components/Projects.tsx](src/components/Projects.tsx) ligne 6 : suppression de `'Rénovation'` du tableau `categories` (aucun projet n'a cette catégorie)
- [src/components/Projects.tsx](src/components/Projects.tsx) lignes 148-167 : la Pagination n'est rendue que si `totalPages > 1`, évitant l'état invalide `count=0`

## Test

- [ ] Vérifier que l'onglet "Rénovation" n'apparaît plus dans la liste des filtres
- [ ] Vérifier que les autres filtres fonctionnent correctement
- [ ] Vérifier que la pagination ne s'affiche pas quand il y a 9 projets ou moins (tous sur une page)
- [ ] Vérifier l'absence de régression sur la navigation

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)