### PR TITLE
fix: Problème visuel cuisine (#12)

### DIFF
--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { Box, Container, Typography, Button, Breadcrumbs, Grid, Modal, IconButton } from '@mui/material'
 import { projectsData } from '../data/projects'
@@ -10,6 +10,10 @@ const ProjectDetail = () => {
   const navigate = useNavigate()
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
   const project = projectsData.find(p => p.id === Number(id))
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' })
+  }, [id])
 
   if (!project) {
     return (


### PR DESCRIPTION
## Résolution de l'issue #12

**Issue :** Problème visuel cuisine

## Cause du bug

React Router v6 ne réinitialise pas le scroll lors des navigations entre routes. Quand l'utilisateur cliquait sur une photo de projet depuis la liste (souvent scrollée), il arrivait sur la page détail au même niveau de scroll qu'avant (2/3 de la page), au lieu d'arriver en haut.

## Changements effectués

- [src/components/ProjectDetail.tsx](src/components/ProjectDetail.tsx) : ajout d'un `useEffect` qui appelle `window.scrollTo({ top: 0, behavior: 'instant' })` à chaque changement de l'`id` de projet — le comportement `'instant'` évite un effet de scroll visible

## Test

- [ ] Cliquer sur un projet depuis la liste en étant scrollé vers le bas → vérifier qu'on arrive bien en haut de la page détail
- [ ] Naviguer entre plusieurs projets → vérifier que chaque page s'ouvre en haut
- [ ] Vérifier l'absence de régression sur la navigation (bouton retour, liens fil d'Ariane)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)