### PR TITLE
fix: Changement projet Meuble sous toit (#13)

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -78,16 +78,15 @@ export const projectsData: Project[] = [
     },
     {
         id: 6,
-        title: 'Meuble Sous Toit',
+        title: 'Meuble penderie sous-pente',
         description: "Création d'un meuble sous pente pour exploiter au mieux l'espace disponible. Rangements pratiques et esthétiques.",
         category: 'Meubles sur mesure',
-        coverImage: new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.30.01 (1).jpeg', import.meta.url).href,
+        coverImage: new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.30.01.jpeg', import.meta.url).href,
         images: [
-            new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.30.01 (1).jpeg', import.meta.url).href,
+            new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.30.01.jpeg', import.meta.url).href,
             new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.29.53.jpeg', import.meta.url).href,
             new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.29.54.jpeg', import.meta.url).href,
             new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.30.01 (1).jpeg', import.meta.url).href,
-            new URL('../assets/meubleSousToit/WhatsApp Image 2025-07-14 at 10.30.01.jpeg', import.meta.url).href,
         ],
     },
     {


### PR DESCRIPTION
## Résolution de l'issue #13

**Issue :** Changement projet Meuble sous toit

## Cause du bug

Le projet utilisait un intitulé générique et affichait en photo de couverture le meuble avec les portes fermées, ce qui ne met pas en valeur l'aménagement intérieur.

## Changements effectués

- [src/data/projects.ts](src/data/projects.ts) ligne 81 : `'Meuble Sous Toit'` → `'Meuble penderie sous-pente'`
- [src/data/projects.ts](src/data/projects.ts) `coverImage` : passage de `...10.30.01 (1).jpeg` (portes fermées) à `...10.30.01.jpeg` (portes ouvertes, montrant les rangements et la tringle)
- `images[0]` mis à jour en cohérence avec le nouveau `coverImage`
- Suppression du doublon `10.30.01 (1).jpeg` qui apparaissait deux fois dans le tableau `images`

## Test

- [ ] Vérifier que la carte du projet affiche "Meuble penderie sous-pente"
- [ ] Vérifier que la photo de couverture montre bien le meuble avec les portes ouvertes
- [ ] Vérifier que la galerie d'images est complète et sans doublons
- [ ] Vérifier l'absence de régression sur les autres projets

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)