### PR TITLE
fix: Passer le site en fr (#20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="fr">
 
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Résolution de l'issue #20

**Issue :** Passer le site en fr

## Cause du bug

L'attribut `lang` de la balise `<html>` dans [index.html](index.html) était défini à `"en"` (anglais). Les navigateurs et extensions comme Google Translate se basent sur cet attribut pour détecter la langue de la page — d'où la proposition de traduction alors que le contenu est déjà en français.

## Changements effectués

- [index.html](index.html) ligne 2 : `<html lang="en">` → `<html lang="fr">`

## Test

- [ ] Vérifier que Google Translate ne propose plus de traduire la page
- [ ] Vérifier que le comportement du site est inchangé

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)